### PR TITLE
fix: mfkey32 always display recovered key as key A

### DIFF
--- a/pug/src/mfkey32.pug
+++ b/pug/src/mfkey32.pug
@@ -265,7 +265,7 @@ block script
                   try {
                     this.$set(this.ss, 'detects', _.unionWith(this.ss.detects, [{
                       block: r0.block,
-                      keyType: r0.isKeyb ? 1 : 0,
+                      keyType: r0.isKeyB ? 1 : 0,
                       key: this.mfkey32v2(r0.uid, r0, r1),
                     }], _.isEqual))
                   } catch (err) {


### PR DESCRIPTION
Reported by Daniele Crudo