### PR TITLE
v0.3.29: add mf1KeysFromDict and bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./dist/index.mjs",
   "name": "chameleon-ultra.js",
   "type": "commonjs",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "bugs": {
     "url": "https://github.com/taichunmin/chameleon-ultra.js/issues"
   },

--- a/pug/src/mfkey32.pug
+++ b/pug/src/mfkey32.pug
@@ -90,7 +90,7 @@ block content
           h6.text-info.my-3 # Read data from tag
           p.my-2 If you have a tag, the preferred method is using the keys to read the tag via ChameleonUltra. If you already have some keys of the tag, you can click "Edit keys" to edit. Otherwise, you can start from the well-known keys. Then you can click "Read Tag".
           h6.text-info.my-3 # Export dump before closing
-          p.my-2 You can click "Export file" to export the data to file. Then you can click "Import file" to import later. #[span.text-danger When you close the webpage, all data in the webpage will lost.]
+          p.my-2 You can click "Export file" to export the data to file. Then you can click "Import file" to import later. #[span.text-danger Please remember to export the dump before closing the page!]
           h6.text-info.my-3 # Learn more about MFKey32
           p.my-2 If you want to learn more about MFKey32, please refer to the Flipper's #[a(target="_blank" href="https://docs.flipper.net/nfc/mfkey32") Recovering MIFARE Classic keys] Document.
     .card.shadow-sm.mb-3
@@ -120,9 +120,10 @@ block content
             textarea.form-control.form-control-sm.flex-fill(v-model="exportimport.text")
             small.text-muted.form-text Click "Copy" to copy text, or click "Apply" to apply change.
           .modal-footer
+            button.btn.btn-outline-secondary(type="button", @click="exportimport?.cb?.()") Cancel
+            button.btn.btn-outline-danger(type="button", @click="exportimport.text = ''") Clear
             button.btn.btn-outline-success(type="button", @click="btnCopy(exportimport.text, $refs.exportimport)") Copy
-            button.btn.btn-secondary(type="button", @click="exportimport?.cb?.()") Cancel
-            button.btn.btn-primary(type="button", @click="exportimport?.cb?.(exportimport.text)") Apply
+            button.btn.btn-outline-primary(type="button", @click="exportimport?.cb?.(exportimport.text)") Apply
     .modal.fade(tabindex="-1", ref="dumpExport")
       .modal-dialog.modal-dialog-centered.modal-xl
         .modal-content
@@ -168,6 +169,7 @@ block script
     const blockToSector = block => block < 128 ? block >>> 2 : 24 + (block >>> 4)
     const toHex = buf => _.toUpper(buf.toString('hex'))
     const WELL_KNOWN_KEYS = _.map(['FFFFFFFFFFFF', 'A0A1A2A3A4A5', 'D3F7D3F7D3F7'], hex => Buffer.from(hex, 'hex'))
+    const isMf1MagicBlock0 = buf => Buffer.isBuffer(buf) && buf.length >= 16 && _.includes([0x08, 0x88], buf[5]) && toHex(buf.subarray(6, 8)) === '0400' && buf[4] === buf.subarray(0, 4).xor()
 
     window.vm = new Vue({
       el: '#app',
@@ -203,9 +205,7 @@ block script
               if (key === 'ss') {
                 try {
                   saved.dump = Buffer.from(saved.dump, 'base64url')
-                } catch (err) {
-                  saved.dump = this.mf1GenEmptyDump()
-                }
+                } catch (err) {}
               }
               this.$set(this, key, _.merge(this[key], saved))
             }
@@ -216,6 +216,7 @@ block script
             storage.setItem(location.pathname, JSON5.stringify(saved))
           }, { deep: true })
         }
+        if (!Buffer.isBuffer(this.ss.dump)) this.ss.dump = this.mf1GenEmptyDump()
       },
       computed: {
         ultra () {
@@ -387,10 +388,20 @@ block script
               default:
                 throw new Error(`Unsupported file extension: ${ext}`)
             }
-            if (_.isNil(res.dump)) throw new Error('Failed to import dump')
+            if (!Buffer.isBuffer(res.dump)) throw new Error('Failed to import dump')
             if (!_.includes([1024, 4096], res.dump.length)) throw new Error(`dump size invalid: ${res.dump?.length} bytes`)
             res.tagType = res.dump.length === 4096 ? 1 : 0
-            this.$set(this, 'ss', res)
+
+            // try anti-collision
+            if (_.isNil(res.uid) && isMf1MagicBlock0(res.dump)) {
+              _.merge(res, {
+                atqa: toHex(res.dump.subarray(6, 8).toReversed()),
+                sak: toHex(res.dump.subarray(5, 6)),
+                uid: toHex(res.dump.subarray(0, 4)),
+              })
+            }
+
+            this.$set(this, 'ss', { ...this.ss, ...res })
             this.mfGrabKeysFromDump()
 
             await this.swalFire({ icon: 'success', title: 'Import success', text: 'Please verify import result. Invalid bytes has been replace with 0x00.' })
@@ -538,7 +549,7 @@ block script
               }
             }
             this.mfMergeKeys(newKeys)
-            await this.swalFire({ icon: 'success', title: `Recovered ${newKeys.length} keys!` })
+            await this.swalFire({ icon: 'success', title: `Recovered ${newKeys.length} keys!`, text: (newKeys.length > 0 ? 'You can repeat whole process to recover more keys.' : 'You can read tag again and then export dump.') })
           } catch (err) {
             ultra.emitter.emit('error', err)
             await this.swalFire({ icon: 'error', title: 'Failed to recover key.', text: err.message })
@@ -604,10 +615,7 @@ block script
         },
         mfGetKeys () {
           try {
-            const keys = _.chain(Buffer.from(this.ss.keys, 'hex').chunk(6))
-              .filter(key => Buffer.isBuffer(key) && key.length === 6)
-              .uniqWith(Buffer.equals)
-              .value()
+            const keys = ChameleonUltra.mf1KeysFromDict(this.ss.keys)
             return keys.length > 0 ? keys : null
           } catch (err) {
             return null

--- a/pug/src/mifare-keychain.pug
+++ b/pug/src/mifare-keychain.pug
@@ -295,7 +295,7 @@ block script
           return flexsearch.search(keyword, limit).map(id => mTags.get(id))
         },
         mfkeys () {
-          return Buffer.from(this.idbKeyVal.mfkeys, 'hex').chunk(6)
+          return ChameleonUltra.mf1KeysFromDict(this.idbKeyVal.mfkeys)
         },
       },
       methods: {

--- a/pug/src/mifare1k.pug
+++ b/pug/src/mifare1k.pug
@@ -360,7 +360,7 @@ block script
               html: `<div class="d-flex flex-column"><div class="progress mb-2"><div class="progress-bar progress-bar-striped" role="progressbar" style="width: ${i / 16 * 100}%"></div></div><div class="d-flex justify-content-between"><span>Reading Mifare / Gen2:</span><span>${i} / 16</span></div></div>`,
             })
             this.showLoading(genSwalCfg(0))
-            const keys = this.mfCardGetKeys()
+            const keys = this.mfGetKeys()
             this.mfCardSetAntiColl(_.first(await ultra.cmdHf14aScan()))
             const failed = []
             for (let i = 0; i < 16; i++) {
@@ -398,7 +398,7 @@ block script
               html: `<div class="d-flex flex-column"><div class="progress mb-2"><div class="progress-bar progress-bar-striped" role="progressbar" style="width: ${i / 16 * 100}%"></div></div><div class="d-flex justify-content-between"><span>Writing Mifare / Gen2:</span><span>${i} / 16</span></div></div>`,
             })
             this.showLoading(genSwalCfg(0))
-            const keys = this.mfCardGetKeys()
+            const keys = this.mfGetKeys()
             const failed = []
             for (let i = 0; i < 16; i++) {
               try {
@@ -593,11 +593,8 @@ block script
           const sectorEml = _.map(sectorData.chunk(16), toHex).join('\n')
           this.$set(this.ss.dump, sectorNo, sectorEml)
         },
-        mfCardGetKeys () {
-          const keys = _.chain(Buffer.from(this.ss.keys, 'hex').chunk(6))
-            .filter(key => Buffer.isBuffer(key) && key.length === 6)
-            .uniqWith(Buffer.equals)
-            .value()
+        mfGetKeys () {
+          const keys = ChameleonUltra.mf1KeysFromDict(this.ss.keys)
           if (keys.length === 0) throw new Error('No keys found')
           return keys
         },

--- a/src/ChameleonUltra.ts
+++ b/src/ChameleonUltra.ts
@@ -3942,6 +3942,7 @@ export class ChameleonUltra {
   /**
    * Convert [Proxmark3](https://github.com/RfidResearchGroup/proxmark3) compatible JSON Object to dump for importing Mifare Classic.
    * @param pm3Json - [Proxmark3](https://github.com/RfidResearchGroup/proxmark3) compatible JSON Object. If a string, `Uint8Array`, `Buffer` is provided, it will be parsed using `JSON.parse`.
+   * @returns The tag data imported from Proxmark3 JSON Object.
    * @group Mifare Classic Related
    * @see [loadFileJSONex | RfidResearchGroup/proxmark3](https://github.com/RfidResearchGroup/proxmark3/blob/c3a7a11ae78558f1cc187570f40e023dd24f8fb6/client/src/fileutils.c#L1444)
    * @example
@@ -4015,6 +4016,7 @@ export class ChameleonUltra {
   /**
    * Convert [Proxmark3](https://github.com/RfidResearchGroup/proxmark3) compatible EML string to dump for importing Mifare Classic.
    * @param eml - The EML string of the Mifare Classic.
+   * @returns The dump data imported from EML.
    * @group Mifare Classic Related
    * @example
    * ```js
@@ -4072,6 +4074,7 @@ export class ChameleonUltra {
   /**
    * Convert [MifareClassicTool](https://play.google.com/store/apps/details?id=de.syss.MifareClassicTool) compatible MCT string to dump for importing Mifare Classic.
    * @param mct - The MCT string of the Mifare Classic.
+   * @returns The dump data imported from MCT.
    * @group Mifare Classic Related
    * @example
    * ```js
@@ -4105,6 +4108,32 @@ export class ChameleonUltra {
       }
     }
     return buf.subarray(0, maxBlkNo < 64 ? 1024 : (maxBlkNo < 128 ? 2048 : 4096))
+  }
+
+  /**
+   * Convert Mifare Keys `.dic` string to keys.
+   * @param dict - Mifare Keys `.dic` string
+   * @returns The keys imported from Mifare Keys `.dic` string.
+   * @group Mifare Classic Related
+   * @example
+   * ```js
+   * // you can run in DevTools of https://taichunmin.idv.tw/chameleon-ultra.js/test.html
+   * await (async () => {
+   *   const { Buffer, ChameleonUltra, TagType } = await import('https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/+esm')
+   *   const dict = '#test\r\nFFFFFFFFFFFF\r\n\r\n'
+   *   const keys = ChameleonUltra.mf1KeysFromDict(dict)
+   *   console.log(keys.map(key => key.toString('hex').toUpperCase()))
+   *   // ['FFFFFFFFFFFF']
+   * })()
+   * ```
+   */
+  static mf1KeysFromDict (dict: string): Buffer[] {
+    if (!_.isString(dict)) throw new TypeError('dict must be a string')
+    dict = dict.replaceAll(/(\r?\n)+/g, '\n').replaceAll(/#[^\n]*\n?/msg, '')
+    return _.chain(Buffer.from(dict, 'hex').chunk(6))
+      .filter(key => Buffer.isBuffer(key) && key.length === 6)
+      .uniqWith(Buffer.equals)
+      .value()
   }
 
   /**


### PR DESCRIPTION
This pull request introduces several updates to improve functionality, enhance user experience, and add new features related to MIFARE Classic operations. Key changes include updates to the UI text, improved handling of dumps and keys, and the addition of a new utility method for processing MIFARE keys.

### User Interface Updates:
* Updated instructional text in `pug/src/mfkey32.pug` to emphasize the importance of exporting dumps before closing the page.
* Enhanced modal buttons in `pug/src/mfkey32.pug` with more descriptive styles and added a "Clear" button for text fields.

### Functional Improvements:
* Added a new utility function `isMf1MagicBlock0` to detect magic block 0 in MIFARE Classic dumps.
* Improved error handling and validation for imported dumps, including checks for buffer type and size.
* Ensured empty dumps are generated when necessary by adding a fallback in the reactive data watcher.

### Code Simplification:
* Replaced inline key filtering logic with the new `ChameleonUltra.mf1KeysFromDict` method in both `pug/src/mfkey32.pug` and `pug/src/mifare1k.pug`. [[1]](diffhunk://#diff-913338012a91dbe4428e430923b5a25535fe2d8aa1b97c2c018ec89754b2b318L607-R618) [[2]](diffhunk://#diff-437e05c919e7ca3c1906933449673654ecd6db302c7f75b7e953c7fdeb90e89eL596-R597)

### New Features:
* Added a static method `mf1KeysFromDict` to `ChameleonUltra` for parsing MIFARE keys from `.dic` strings, complete with documentation and examples.

### Documentation Enhancements:
* Updated JSDoc comments in `src/ChameleonUltra.ts` to include return descriptions for methods related to importing MIFARE Classic data (e.g., from JSON, EML, and MCT formats). [[1]](diffhunk://#diff-42b3f6e6202e74f8e3d6d0e1ff2b87994b74a7637c1fc3f4616bf8a2588366d2R3945) [[2]](diffhunk://#diff-42b3f6e6202e74f8e3d6d0e1ff2b87994b74a7637c1fc3f4616bf8a2588366d2R4019) [[3]](diffhunk://#diff-42b3f6e6202e74f8e3d6d0e1ff2b87994b74a7637c1fc3f4616bf8a2588366d2R4077)