### PR TITLE
v0.4.0: breaking change of cmdEm410xScan

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./dist/index.mjs",
   "name": "chameleon-ultra.js",
   "type": "commonjs",
-  "version": "0.3.34",
+  "version": "0.4.0",
   "bugs": {
     "url": "https://github.com/taichunmin/chameleon-ultra.js/issues"
   },

--- a/pug/src/lf-em410x.pug
+++ b/pug/src/lf-em410x.pug
@@ -185,7 +185,7 @@ block script
           const { ultra } = this
           try {
             this.showLoading({ text: 'Scanning tag...' })
-            this.ss.uid = toHex(await ultra.cmdEm410xScan())
+            this.ss.uid = toHex((await ultra.cmdEm410xScan())?.id)
             Swal.close()
           } catch (err) {
             ultra.emitter.emit('error', err)
@@ -202,7 +202,7 @@ block script
             const newKey = Buffer.from('20206666', 'hex')
             const oldKeys = this.t55xxGetKeys()
             await ultra.cmdEm410xWriteToT55xx(uid, newKey, oldKeys)
-            const uid2 = await ultra.cmdEm410xScan()
+            const uid2 = (await ultra.cmdEm410xScan())?.id
             if (!uid.equals(uid2)) throw new Error(`ID mismatch after write, scanned = ${toHex(uid2)}`)
             await this.swalFire({ icon: 'success', title: 'Write success' })
           } catch (err) {

--- a/src/ChameleonUltra.test.ts
+++ b/src/ChameleonUltra.test.ts
@@ -508,13 +508,13 @@ describe('ChameleonUltra with BufferMockAdapter', () => {
   test('#cmdEm410xScan()', async () => {
     // arrange
     adapter.send.push(Buffer.from('11ef 03e9 0068 0000 ac 00', 'hex')) // DeviceMode.READER
-    adapter.send.push(Buffer.from('11ef 0bb8 0040 0005 f8 0000002076 6a', 'hex'))
+    adapter.send.push(Buffer.from('11ef 0bb8 0040 0010 ed 0067deadbeef88000000000000000000 d9', 'hex'))
 
     // act
     const actual = await ultra.cmdEm410xScan()
 
     // assert
-    expect(actual).toEqual(Buffer.from('0000002076', 'hex'))
+    expect(actual.id).toEqual(Buffer.from('deadbeef88', 'hex'))
     expect(adapter.recv).toEqual([
       Buffer.from('11ef 03e9 0000 0001 13 01 ff', 'hex'), // DeviceMode.READER
       Buffer.from('11ef 0bb8 0000 0000 3d 00', 'hex'),
@@ -529,14 +529,7 @@ describe('ChameleonUltra with BufferMockAdapter', () => {
       adapter.send.push(Buffer.from('11ef 0bb8 0041 0000 fc 00', 'hex'))
 
       // act
-      const actual = await ultra.cmdEm410xScan()
-
-      // assert
-      expect(actual).toEqual(Buffer.from('0000002076'))
-      expect(adapter.recv).toEqual([
-        Buffer.from('11ef 03e9 0000 0001 13 01 ff', 'hex'), // DeviceMode.READER
-        Buffer.from('11ef 0bb8 0000 0000 3d 00', 'hex'),
-      ])
+      await ultra.cmdEm410xScan()
     } catch (err) {
       expect(err.message).toMatch(/tag not found/)
     }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -599,6 +599,13 @@ export const isValidFreqType = createIsValueOfArr([
   FreqType.LF,
 ] as const)
 
+export const TagTypeLfIdLen = new Map<TagType, number>([
+  [TagType.EM410X, 5],
+  [TagType.EM410X_16, 5],
+  [TagType.EM410X_32, 5],
+  [TagType.EM410X_64, 5],
+])
+
 // facility, id, issueLevel, oem
 export const HidProxFormatLimit = new Map<HidProxFormat, [number, number, number, number]>([
   [HidProxFormat.H10301, [0xFF, 0xFFFF, 0, 0]],


### PR DESCRIPTION
This pull request introduces a breaking change to the `cmdEm410xScan` API, refactoring it to return a structured object containing both the tag type and the ID, rather than just a buffer. It also adds support for handling different EM410X tag types and their respective ID lengths, updates related usages in the codebase, and bumps the package version to `0.4.0`.

### API Changes and Refactoring
* Refactored `cmdEm410xScan` in `src/ChameleonUltra.ts` to return an object `{ tagType, id }` instead of a `Buffer`, and added logic to handle multiple EM410X tag types and their ID lengths using the new `TagTypeLfIdLen` map. [[1]](diffhunk://#diff-42b3f6e6202e74f8e3d6d0e1ff2b87994b74a7637c1fc3f4616bf8a2588366d2L2238-R2258) [[2]](diffhunk://#diff-00310f3f832445de900d07b99183266cabc84aa21246ec7f1d136635b3108f79R602-R608)
* Updated example documentation and usages to reflect the new return value structure for `cmdEm410xScan`.

### Test and Usage Updates
* Updated tests in `src/ChameleonUltra.test.ts` to expect the new object structure from `cmdEm410xScan`, checking both `tagType` and `id`. [[1]](diffhunk://#diff-52513bcf14e4d0a0b0b09ea8a8ef794353387864f2b77a3bce2e78aa7e2fad94L511-R517) [[2]](diffhunk://#diff-52513bcf14e4d0a0b0b09ea8a8ef794353387864f2b77a3bce2e78aa7e2fad94L532-R532)
* Modified usages in `pug/src/lf-em410x.pug` to access the `.id` property from the scan result. [[1]](diffhunk://#diff-e492b7ccb8f36fe8525eff90d42aa521ee7adfbef759bd5ada31e7d96401cd30L188-R188) [[2]](diffhunk://#diff-e492b7ccb8f36fe8525eff90d42aa521ee7adfbef759bd5ada31e7d96401cd30L205-R205)

### Package Version
* Bumped package version to `0.4.0` in `package.json` to signal breaking changes and new functionality.